### PR TITLE
Update prometheus_exporter startup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,6 @@ gem 'puma', '~> 4.1'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 
-# Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.2', require: false
-
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,8 +56,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
-    bootsnap (1.4.5)
-      msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
     concurrent-ruby (1.1.6)
@@ -84,7 +82,6 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
-    msgpack (1.3.3)
     nio4r (2.5.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
@@ -151,7 +148,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bootsnap (>= 1.4.2)
   byebug
   foreman (~> 0.87.0)
   listen (>= 3.0.5, < 3.3)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-stats: bundle exec prometheus_exporter 
+stats: bundle exec prometheus_exporter -b 0.0.0.0

--- a/bin/devctl.sh
+++ b/bin/devctl.sh
@@ -1,11 +1,16 @@
 #! /bin/bash
 export RAILS_ENV=development
+export PORT=3000
 
-if [ "$1" == "up" ] ; then
-    docker-compose up --build -d
-    docker-compose exec web rake db:create db:migrate
-elif [ "$1" == "sh" ] ; then
-    docker-compose exec web sh
-else
-    docker-compose "$@"
-fi
+case "$1" in
+    "up")
+        docker-compose up --build -d
+        docker-compose exec web rake db:create db:migrate
+    ;;
+    "sh")
+        docker-compose exec web sh
+    ;;
+    *)
+         docker-compose "$@"
+    ;;
+esac

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,3 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
In discourse/prometheus_exporter#103 the default port binding behavior
was changed to only bind to localhost. Since we run in a container, bind
to everything.

While we're here
  - get rid of bootsnap since it seems to fail a lot and this is a test
    app
  - make devctl.sh a bit cleaner
  - add PORT back