### PR TITLE
list correct contexts

### DIFF
--- a/bin/create-gh-deployment.sh
+++ b/bin/create-gh-deployment.sh
@@ -2,9 +2,13 @@
 
 curl --user "${GITHUB_USER}:${GITHUB_TOKEN}" -sSL -X POST -d '
 {
+  "description": "triggered via circleci"
   "ref": "refs/heads/master",
   "payload": {
     "do": "it"
   },
-  "description": "triggered via circleci"
+  "required_contexts": [
+    "ci/circleci: test",
+    "ci/circleci: build"
+  ]
 }' https://api.github.com/repos/oddhoc/sample-api-app/deployments


### PR DESCRIPTION
By default deploys require all status contests to be passing in order to trigger a deploy.  Since we deploy thought CircleCI which creates a context for us, we need to curate the list.  This PR does that.